### PR TITLE
Implement interactive TUI for macOS cache and log cleanup

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+## Branch naming convention
+- Feature: `feature/XX-description`
+- Bugfix: `bugfix/XX-description`
+
 ## What changed
 - 
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+CXX := clang++
+VERSION ?= 0.1.0
+PREFIX ?= /usr/local
+DESTDIR ?=
+
+CXXFLAGS := -std=c++20 -Wall -Wextra -Wpedantic -Iinclude -DMCLEANER_VERSION=\"$(VERSION)\"
+LDFLAGS := -lncurses
+SOURCES := src/Tui.cpp src/Cleaner.cpp src/main.cpp
+TARGET := mcleaner
+
+all: $(TARGET)
+
+$(TARGET): $(SOURCES)
+	$(CXX) $(CXXFLAGS) $(SOURCES) $(LDFLAGS) -o $(TARGET)
+
+clean:
+	rm -f $(TARGET)
+
+install: $(TARGET)
+	install -d "$(DESTDIR)$(PREFIX)/bin"
+	install -m 0755 "$(TARGET)" "$(DESTDIR)$(PREFIX)/bin/$(TARGET)"
+
+uninstall:
+	rm -f "$(DESTDIR)$(PREFIX)/bin/$(TARGET)"
+
+.PHONY: all clean install uninstall

--- a/include/Cleaner.h
+++ b/include/Cleaner.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "CleaningItem.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+class Cleaner {
+public:
+    struct CleanResult {
+        std::string name;
+        std::string path;
+        std::string risk;
+        std::string status;
+        std::size_t entries{0};
+        std::string detail;
+    };
+
+    struct ItemPreview {
+        std::size_t entries{0};
+        std::uintmax_t bytes{0};
+        bool exists{false};
+        bool accessible{true};
+        bool safe{false};
+    };
+
+    Cleaner();
+
+    const std::vector<CleaningItem>& items() const;
+    std::vector<CleaningItem>& items();
+
+    bool isSafePath(const std::string& path) const;
+    std::size_t scan();
+    std::size_t scanHiddenCandidates(std::vector<std::string>& messages);
+    std::size_t scanHomeDirectoryCandidates(std::vector<std::string>& messages);
+    std::vector<ItemPreview> previewItemsFor(const std::vector<CleaningItem>& items) const;
+    std::vector<ItemPreview> previewItems() const;
+    std::size_t previewSelected(std::vector<std::string>& messages, std::uintmax_t& totalBytes) const;
+    CleanResult cleanItem(const CleaningItem& item, bool dryRun = false) const;
+    std::size_t cleanSelected(
+        std::vector<std::string>& messages,
+        bool dryRun = false,
+        const std::function<void(std::size_t, std::size_t, const CleaningItem&)>& onProgress = {},
+        std::vector<CleanResult>* results = nullptr
+    );
+
+private:
+    std::vector<CleaningItem> items_;
+
+    static std::vector<CleaningItem> defaultItems();
+    static std::size_t removePathContents(const std::string& path, std::string& message);
+};

--- a/include/CleaningItem.h
+++ b/include/CleaningItem.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+struct CleaningItem {
+    std::string name;
+    std::string path;
+    std::string risk{"safe"};
+    bool hidden{false};
+    bool selected{true};
+    bool selectable{true};
+};

--- a/include/Tui.h
+++ b/include/Tui.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "Cleaner.h"
+
+#include <cstdint>
+#include <future>
+#include <string>
+#include <vector>
+
+class Tui {
+public:
+    explicit Tui(bool dryRun = false);
+    int run();
+
+private:
+    Cleaner cleaner_;
+    bool dryRun_{false};
+
+    static bool confirmClean();
+    static bool confirmReviewSelection(const CleaningItem& item);
+    static void showAccessDeniedDialog(const std::vector<std::string>& deniedPaths);
+    static void drawProgress(std::size_t done, std::size_t total, const std::string& label);
+    static void showPagedLines(
+        const std::string& title,
+        const std::string& summary,
+        const std::vector<std::string>& lines,
+        const std::string& footerLeft = "",
+        const std::string& footerRight = ""
+    );
+    static void showPreviewTable(
+        const std::vector<CleaningItem>& items,
+        const std::vector<Cleaner::ItemPreview>& previews,
+        std::size_t totalEntries,
+        std::uintmax_t totalBytes
+    );
+    static void showCleanResultTable(
+        const std::vector<Cleaner::CleanResult>& results,
+        std::size_t totalEntriesRemoved,
+        bool dryRun
+    );
+    void requestPreviewRefresh();
+    void startPreviewJobIfNeeded();
+    void collectPreviewJobIfReady();
+    bool cacheMatchesCurrentItems() const;
+    void selectAll(bool selected);
+    void appendLog(const std::vector<std::string>& lines) const;
+    void appendCleanLog(std::size_t removed, const std::vector<std::string>& lines) const;
+    void appendPreviewLog(std::size_t entries, std::uintmax_t bytes, const std::vector<std::string>& lines) const;
+    void writeJsonReport(std::size_t removed, const std::vector<std::string>& lines) const;
+    void toggleItem(int index);
+
+    struct PreviewJobResult {
+        std::vector<CleaningItem> items;
+        std::vector<Cleaner::ItemPreview> previews;
+    };
+
+    std::future<PreviewJobResult> previewFuture_;
+    bool previewJobRunning_{false};
+    bool previewRefreshRequested_{true};
+    std::vector<CleaningItem> cachedPreviewItems_;
+    std::vector<Cleaner::ItemPreview> cachedPreviews_;
+};

--- a/src/Cleaner.cpp
+++ b/src/Cleaner.cpp
@@ -1,0 +1,555 @@
+#include "Cleaner.h"
+
+#include <filesystem>
+#include <cstdlib>
+#include <system_error>
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_set>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace {
+bool startsWithPath(const fs::path& fullPath, const fs::path& prefixPath) {
+    auto fullIt = fullPath.begin();
+    auto prefixIt = prefixPath.begin();
+    for (; prefixIt != prefixPath.end(); ++prefixIt, ++fullIt) {
+        if (fullIt == fullPath.end() || *fullIt != *prefixIt) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::string toLower(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    return value;
+}
+
+std::string classifyHiddenPath(const fs::path& relativePath) {
+    const std::string rel = toLower(relativePath.generic_string());
+
+    static const std::unordered_set<std::string> neverRoots = {
+        ".ssh",
+        ".gnupg",
+        ".aws",
+        ".azure",
+        ".kube",
+        ".config",
+        ".docker",
+        ".local",
+    };
+
+    static const std::unordered_set<std::string> safeRoots = {
+        ".cache",
+        ".npm",
+        ".yarn",
+        ".pnpm-store",
+        ".gradle",
+        ".m2",
+        ".cargo",
+        ".ivy2",
+    };
+
+    const std::string root = toLower(relativePath.begin() == relativePath.end() ? "" : (*relativePath.begin()).string());
+    if (neverRoots.contains(root)) {
+        return "never";
+    }
+    if (safeRoots.contains(root)) {
+        return "safe";
+    }
+
+    if (rel.find("cache") != std::string::npos || rel.find("tmp") != std::string::npos) {
+        return "safe";
+    }
+    return "review";
+}
+
+std::string hiddenDisplayName(const fs::path& relativePath) {
+    const std::string base = relativePath.filename().string();
+    if (base.empty()) {
+        return ".hidden";
+    }
+    return base;
+}
+
+std::string classifyHomePath(const fs::path& namePath) {
+    const std::string name = toLower(namePath.filename().string());
+
+    static const std::unordered_set<std::string> safeNames = {
+        "cache",
+        "caches",
+        "tmp",
+        "temp",
+        "logs",
+    };
+
+    static const std::unordered_set<std::string> defaultSystemNames = {
+        "library",
+        "applications",
+        "desktop",
+        "documents",
+        "downloads",
+        "movies",
+        "music",
+        "pictures",
+        "public",
+        "sites",
+    };
+
+    if (safeNames.contains(name)) {
+        return "safe";
+    }
+    if (defaultSystemNames.contains(name)) {
+        return "never";
+    }
+    return "safe";
+}
+
+Cleaner::ItemPreview previewPath(const fs::path& path, bool safe) {
+    Cleaner::ItemPreview result;
+    result.safe = safe;
+
+    std::error_code ec;
+    const bool pathExists = fs::exists(path, ec);
+    if (ec) {
+        result.exists = true;
+        result.accessible = false;
+        return result;
+    }
+
+    if (!pathExists) {
+        return result;
+    }
+
+    result.exists = true;
+
+    if (fs::is_regular_file(path, ec)) {
+        result.entries = 1;
+        result.bytes = fs::file_size(path, ec);
+        if (ec) {
+            result.bytes = 0;
+        }
+        return result;
+    }
+
+    if (!fs::is_directory(path, ec)) {
+        if (ec) {
+            result.accessible = false;
+        }
+        return result;
+    }
+
+    fs::directory_iterator rootIt(path, ec);
+    if (ec) {
+        result.accessible = false;
+        return result;
+    }
+
+    fs::recursive_directory_iterator it(
+        path,
+        fs::directory_options::skip_permission_denied,
+        ec
+    );
+    fs::recursive_directory_iterator end;
+    while (!ec && it != end) {
+        const auto& entry = *it;
+        ++result.entries;
+        if (entry.is_regular_file(ec)) {
+            const auto size = entry.file_size(ec);
+            if (!ec) {
+                result.bytes += size;
+            }
+        }
+        ec.clear();
+        it.increment(ec);
+    }
+
+    if (ec) {
+        result.accessible = false;
+    }
+
+    return result;
+}
+}
+
+Cleaner::Cleaner() : items_(defaultItems()) {}
+
+const std::vector<CleaningItem>& Cleaner::items() const { return items_; }
+
+std::vector<CleaningItem>& Cleaner::items() { return items_; }
+
+bool Cleaner::isSafePath(const std::string& path) const {
+    const char* home = std::getenv("HOME");
+    if (!home || path.empty()) {
+        return false;
+    }
+
+    std::error_code ec;
+    const fs::path homePath = fs::path(home).lexically_normal();
+    fs::path candidatePath = fs::path(path).lexically_normal();
+
+    const fs::path canonicalHome = fs::weakly_canonical(homePath, ec);
+    if (!ec) {
+        ec.clear();
+        const fs::path canonicalCandidate = fs::weakly_canonical(candidatePath, ec);
+        if (!ec) {
+            return startsWithPath(canonicalCandidate, canonicalHome);
+        }
+    }
+
+    return startsWithPath(candidatePath, homePath);
+}
+
+std::vector<CleaningItem> Cleaner::defaultItems() {
+    const char* home = std::getenv("HOME");
+    std::string homeDir = home ? home : "";
+
+    return {
+        {"Trash", homeDir + "/.Trash", "safe", false, true, true},
+        {"Caches", homeDir + "/Library/Caches", "safe", false, true, true},
+        {"Logs", homeDir + "/Library/Logs", "safe", false, true, true},
+        {"Temp", homeDir + "/.tmp", "safe", false, true, true},
+    };
+}
+
+std::size_t Cleaner::scan() {
+    items_ = defaultItems();
+    std::vector<std::string> ignoredMessages;
+    scanHomeDirectoryCandidates(ignoredMessages);
+    return items_.size();
+}
+
+std::size_t Cleaner::scanHiddenCandidates(std::vector<std::string>& messages) {
+    messages.clear();
+
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        messages.push_back("HiddenScan: HOME not available.");
+        return 0;
+    }
+
+    const fs::path homePath = fs::path(home);
+    std::error_code ec;
+    fs::directory_iterator it(homePath, fs::directory_options::skip_permission_denied, ec);
+    if (ec) {
+        messages.push_back("HiddenScan: cannot read home directory.");
+        return 0;
+    }
+
+    std::unordered_set<std::string> existing;
+    for (const auto& item : items_) {
+        existing.insert(fs::path(item.path).lexically_normal().string());
+    }
+
+    std::size_t added = 0;
+    std::size_t safeAdded = 0;
+    std::size_t reviewAdded = 0;
+    std::size_t neverAdded = 0;
+
+    for (const auto& entry : it) {
+        if (ec) {
+            ec.clear();
+            continue;
+        }
+
+        const fs::path candidate = entry.path();
+        const std::string name = candidate.filename().string();
+        if (name.empty() || name[0] != '.') {
+            continue;
+        }
+        if (!entry.is_directory(ec)) {
+            ec.clear();
+            continue;
+        }
+
+        const std::string normalized = candidate.lexically_normal().string();
+        if (existing.contains(normalized)) {
+            continue;
+        }
+
+        const fs::path relative = fs::relative(candidate, homePath, ec);
+        ec.clear();
+        const std::string risk = classifyHiddenPath(relative.empty() ? candidate.filename() : relative);
+        const bool selectable = (risk == "safe");
+
+        items_.push_back(CleaningItem{
+            hiddenDisplayName(relative.empty() ? candidate.filename() : relative),
+            normalized,
+            risk,
+            true,
+            selectable,
+            selectable,
+        });
+
+        existing.insert(normalized);
+        ++added;
+        if (risk == "safe") {
+            ++safeAdded;
+        } else if (risk == "review") {
+            ++reviewAdded;
+        } else {
+            ++neverAdded;
+        }
+    }
+
+    messages.push_back(
+        "HiddenScan: added " + std::to_string(added) +
+        " candidates (safe=" + std::to_string(safeAdded) +
+        ", review=" + std::to_string(reviewAdded) +
+        ", never=" + std::to_string(neverAdded) + ")."
+    );
+    messages.push_back("HiddenScan: only risk=safe candidates are selectable by default.");
+    return added;
+}
+
+std::size_t Cleaner::scanHomeDirectoryCandidates(std::vector<std::string>& messages) {
+    messages.clear();
+
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        messages.push_back("HomeScan: HOME not available.");
+        return 0;
+    }
+
+    const fs::path homePath = fs::path(home);
+    std::error_code ec;
+    fs::directory_iterator it(homePath, fs::directory_options::skip_permission_denied, ec);
+    if (ec) {
+        messages.push_back("HomeScan: cannot read home directory.");
+        return 0;
+    }
+
+    std::unordered_set<std::string> existing;
+    for (const auto& item : items_) {
+        existing.insert(fs::path(item.path).lexically_normal().string());
+    }
+
+    std::size_t added = 0;
+    std::size_t safeAdded = 0;
+    std::size_t reviewAdded = 0;
+    std::size_t neverAdded = 0;
+
+    for (const auto& entry : it) {
+        if (ec) {
+            ec.clear();
+            continue;
+        }
+
+        if (!entry.is_directory(ec)) {
+            ec.clear();
+            continue;
+        }
+
+        const fs::path candidate = entry.path();
+        const std::string name = candidate.filename().string();
+        if (name.empty() || name[0] == '.') {
+            continue;
+        }
+
+        const std::string normalized = candidate.lexically_normal().string();
+        if (existing.contains(normalized)) {
+            continue;
+        }
+
+        const std::string risk = classifyHomePath(candidate.filename());
+        const bool selectable = (risk == "safe");
+
+        items_.push_back(CleaningItem{
+            name,
+            normalized,
+            risk,
+            false,
+            false,
+            selectable,
+        });
+
+        existing.insert(normalized);
+        ++added;
+        if (risk == "safe") {
+            ++safeAdded;
+        } else if (risk == "review") {
+            ++reviewAdded;
+        } else {
+            ++neverAdded;
+        }
+    }
+
+    messages.push_back(
+        "HomeScan: added " + std::to_string(added) +
+        " directories (safe=" + std::to_string(safeAdded) +
+        ", review=" + std::to_string(reviewAdded) +
+        ", never=" + std::to_string(neverAdded) + ")."
+    );
+    messages.push_back("HomeScan: non-system directories are safe and selectable; system defaults stay protected.");
+    return added;
+}
+
+std::vector<Cleaner::ItemPreview> Cleaner::previewItems() const {
+    return previewItemsFor(items_);
+}
+
+std::vector<Cleaner::ItemPreview> Cleaner::previewItemsFor(const std::vector<CleaningItem>& items) const {
+    std::vector<ItemPreview> previews;
+    previews.reserve(items.size());
+
+    for (const auto& item : items) {
+        const bool safe = isSafePath(item.path);
+        previews.push_back(previewPath(item.path, safe));
+    }
+
+    return previews;
+}
+
+std::size_t Cleaner::removePathContents(const std::string& path, std::string& message) {
+    std::error_code ec;
+    if (!fs::exists(path, ec)) {
+        message = "Missing: " + path;
+        return 0;
+    }
+
+    std::size_t removed = 0;
+    if (fs::is_regular_file(path, ec) || fs::is_symlink(path, ec)) {
+        removed = fs::remove(path, ec) ? 1 : 0;
+    } else if (fs::is_directory(path, ec)) {
+        for (const auto& entry : fs::directory_iterator(path, ec)) {
+            if (ec) {
+                message = "Failed listing: " + path + " (" + ec.message() + ")";
+                return removed;
+            }
+            removed += static_cast<std::size_t>(fs::remove_all(entry.path(), ec));
+            if (ec) {
+                message = "Partial clean: " + path + " (" + ec.message() + ")";
+                return removed;
+            }
+        }
+    } else {
+        message = "Skipped unsupported path: " + path;
+        return 0;
+    }
+
+    message = "Removed from: " + path + " (" + std::to_string(removed) + " entries)";
+    return removed;
+}
+
+std::size_t Cleaner::previewSelected(std::vector<std::string>& messages, std::uintmax_t& totalBytes) const {
+    messages.clear();
+    totalBytes = 0;
+    std::size_t totalEntries = 0;
+
+    const auto previews = previewItems();
+    for (std::size_t i = 0; i < items_.size(); ++i) {
+        const auto& item = items_[i];
+        const auto& preview = previews[i];
+        if (!item.selected) {
+            continue;
+        }
+
+        const char* risk = item.risk.c_str();
+        if (!preview.exists) {
+            messages.push_back(item.name + " [" + risk + "]: missing");
+            continue;
+        }
+        if (!preview.accessible) {
+            messages.push_back(item.name + " [" + risk + "]: access denied (grant Full Disk Access to terminal/app)");
+            continue;
+        }
+
+        totalEntries += preview.entries;
+        totalBytes += preview.bytes;
+        messages.push_back(
+            item.name +
+            " [" + risk + "]: " +
+            std::to_string(preview.entries) +
+            " entries, " +
+            std::to_string(preview.bytes) +
+            " bytes"
+        );
+    }
+
+    return totalEntries;
+}
+
+std::size_t Cleaner::cleanSelected(
+    std::vector<std::string>& messages,
+    bool dryRun,
+    const std::function<void(std::size_t, std::size_t, const CleaningItem&)>& onProgress,
+    std::vector<CleanResult>* results
+) {
+    std::size_t total = 0;
+    std::size_t selectedTotal = 0;
+    std::size_t processed = 0;
+    messages.clear();
+    if (results) {
+        results->clear();
+    }
+
+    for (const auto& item : items_) {
+        if (item.selected) {
+            ++selectedTotal;
+        }
+    }
+
+    for (const auto& item : items_) {
+        if (!item.selected) continue;
+        ++processed;
+        const CleanResult result = cleanItem(item, dryRun);
+        messages.push_back(item.name + ": " + result.detail);
+        if (result.status == "removed") {
+            total += result.entries;
+        }
+        if (results) {
+            results->push_back(result);
+        }
+        if (onProgress) {
+            onProgress(processed, selectedTotal, item);
+        }
+    }
+    return total;
+}
+
+Cleaner::CleanResult Cleaner::cleanItem(const CleaningItem& item, bool dryRun) const {
+    if (!isSafePath(item.path)) {
+        return CleanResult{item.name, item.path, item.risk, "skipped", 0, "Skipped unsafe path: " + item.path};
+    }
+    if (!item.selectable) {
+        return CleanResult{item.name, item.path, item.risk, "skipped", 0, "Skipped protected candidate (risk=" + item.risk + ")"};
+    }
+
+    if (dryRun) {
+        const auto preview = previewPath(fs::path(item.path), true);
+        if (!preview.exists) {
+            return CleanResult{item.name, item.path, item.risk, "missing", 0, "[dry-run] Missing: " + item.path};
+        }
+        if (!preview.accessible) {
+            return CleanResult{item.name, item.path, item.risk, "error", 0, "[dry-run] Access denied: " + item.path};
+        }
+        return CleanResult{
+            item.name,
+            item.path,
+            item.risk,
+            "dry-run",
+            preview.entries,
+            "[dry-run] Would clean: " + item.path + " (" + std::to_string(preview.entries) + " entries)"
+        };
+    }
+
+    std::string message;
+    // Precaucion: esta llamada elimina de forma recursiva el contenido de la ruta seleccionada.
+    // Solo debe ejecutarse sobre ubicaciones seguras del usuario y tras confirmacion explicita.
+    const std::size_t removedNow = removePathContents(item.path, message);
+
+    std::string status = "done";
+    if (message.rfind("Removed from:", 0) == 0) {
+        status = "removed";
+    } else if (message.rfind("Missing:", 0) == 0) {
+        status = "missing";
+    } else if (message.rfind("Failed", 0) == 0 || message.rfind("Partial clean:", 0) == 0) {
+        status = "error";
+    }
+    return CleanResult{item.name, item.path, item.risk, status, removedNow, message};
+}

--- a/src/Tui.cpp
+++ b/src/Tui.cpp
@@ -1,0 +1,1428 @@
+#include "Tui.h"
+
+#include <ncurses.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+enum ColorPairId {
+    COLOR_HEADER = 1,
+    COLOR_SAFE = 2,
+    COLOR_SKIP = 3,
+    COLOR_STATUS = 4,
+    COLOR_SELECTED = 5,
+    COLOR_BAR_BG = 6,
+    COLOR_BAR_KEY = 7,
+    COLOR_MODAL_ERROR = 8,
+    COLOR_MODAL_WARNING = 9,
+    COLOR_HIDDEN = 10,
+    COLOR_STATUS_OK = 11,
+    COLOR_STATUS_WARN = 12,
+    COLOR_STATUS_ERR = 13,
+};
+
+void initColors() {
+    if (!has_colors()) {
+        return;
+    }
+
+    start_color();
+    use_default_colors();
+    init_pair(COLOR_HEADER, COLOR_CYAN, -1);
+    init_pair(COLOR_SAFE, COLOR_GREEN, -1);
+    init_pair(COLOR_SKIP, COLOR_YELLOW, -1);
+    init_pair(COLOR_STATUS, COLOR_BLACK, COLOR_CYAN);
+    init_pair(COLOR_SELECTED, COLOR_WHITE, -1);
+    init_pair(COLOR_BAR_BG, COLOR_WHITE, COLOR_BLUE);
+    init_pair(COLOR_BAR_KEY, COLOR_WHITE, COLOR_BLACK);
+    init_pair(COLOR_MODAL_ERROR, COLOR_WHITE, COLOR_RED);
+    init_pair(COLOR_MODAL_WARNING, COLOR_BLACK, COLOR_YELLOW);
+    init_pair(COLOR_HIDDEN, COLOR_CYAN, -1);
+    init_pair(COLOR_STATUS_OK, COLOR_GREEN, -1);
+    init_pair(COLOR_STATUS_WARN, COLOR_YELLOW, -1);
+    init_pair(COLOR_STATUS_ERR, COLOR_RED, -1);
+}
+
+void drawCentered(int row, const std::string& text) {
+    const int cols = COLS;
+    const int x = std::max(0, (cols - static_cast<int>(text.size())) / 2);
+    mvprintw(row, x, "%s", text.c_str());
+}
+
+void drawBottomBar() {
+    const int y = LINES - 1;
+    const bool colors = has_colors();
+
+    if (colors) {
+        attron(COLOR_PAIR(COLOR_BAR_BG));
+    } else {
+        attron(A_REVERSE);
+    }
+    mvhline(y, 0, ' ', COLS);
+
+    struct BottomAction {
+        std::string key;
+        std::string label;
+        std::string compactLabel;
+    };
+    const std::vector<BottomAction> actions = {
+        {"1", "Toggle", "Tog"},
+        {"2", "All", "All"},
+        {"3", "None", "None"},
+        {"4", "Preview", "Prev"},
+        {"5", "Clean", "Clean"},
+        {"6", "Rescan", "Scan"},
+        {"7", "Hidden", "Hid"},
+        {"8", "RiskMark", "Risk"},
+        {"9", "Help", "Help"},
+        {"10", "Quit", "Quit"},
+    };
+
+    enum class LabelMode {
+        Full,
+        Compact,
+        KeyOnly,
+    };
+
+    auto neededWidth = [&actions](LabelMode mode) {
+        int width = 0;
+        for (const auto& action : actions) {
+            const int keyBoxWidth = std::max(3, static_cast<int>(action.key.size()) + 2);
+            width += keyBoxWidth;
+            if (mode != LabelMode::KeyOnly) {
+                const std::string& label = (mode == LabelMode::Compact) ? action.compactLabel : action.label;
+                width += 1 + static_cast<int>(label.size());
+            }
+            width += 2;
+        }
+        return width;
+    };
+
+    LabelMode mode = LabelMode::Full;
+    if (neededWidth(LabelMode::Full) >= COLS) {
+        mode = LabelMode::Compact;
+    }
+    if (neededWidth(LabelMode::Compact) >= COLS) {
+        mode = LabelMode::KeyOnly;
+    }
+
+    int x = 0;
+    for (const auto& action : actions) {
+        const std::string& key = action.key;
+        const std::string& label = (mode == LabelMode::Compact) ? action.compactLabel : action.label;
+        const int keyBoxWidth = std::max(3, static_cast<int>(key.size()) + 2);
+        const int labelWidth = (mode == LabelMode::KeyOnly) ? 0 : static_cast<int>(label.size());
+        const int segmentWidth = keyBoxWidth + ((mode == LabelMode::KeyOnly) ? 0 : (1 + labelWidth)) + 2;
+
+        if (x + segmentWidth >= COLS) {
+            break;
+        }
+
+        if (colors) {
+            attron(COLOR_PAIR(COLOR_BAR_KEY) | A_BOLD);
+        } else {
+            attron(A_BOLD | A_REVERSE);
+        }
+        mvhline(y, x, ' ', keyBoxWidth);
+        const int keyX = x + std::max(0, (keyBoxWidth - static_cast<int>(key.size())) / 2);
+        mvprintw(y, keyX, "%s", key.c_str());
+        if (colors) {
+            attroff(COLOR_PAIR(COLOR_BAR_KEY) | A_BOLD);
+            attron(COLOR_PAIR(COLOR_BAR_BG));
+        } else {
+            attroff(A_BOLD | A_REVERSE);
+            attron(A_REVERSE);
+        }
+
+        if (mode != LabelMode::KeyOnly) {
+            mvprintw(y, x + keyBoxWidth + 1, "%s", label.c_str());
+        }
+        x += segmentWidth;
+    }
+
+    if (colors) {
+        attroff(COLOR_PAIR(COLOR_BAR_BG));
+    } else {
+        attroff(A_REVERSE);
+    }
+}
+
+std::string fitText(const std::string& text, int width);
+
+void drawStatusBar(const std::string& text) {
+    mvhline(LINES - 2, 0, ' ', COLS);
+    if (has_colors()) {
+        attron(COLOR_PAIR(COLOR_STATUS));
+    } else {
+        attron(A_REVERSE);
+    }
+
+    mvhline(LINES - 2, 0, ' ', COLS);
+    mvprintw(LINES - 2, 1, "%s", fitText(text, std::max(1, COLS - 2)).c_str());
+
+    if (has_colors()) {
+        attroff(COLOR_PAIR(COLOR_STATUS));
+    } else {
+        attroff(A_REVERSE);
+    }
+}
+
+void drawFooterProgress(std::size_t done, std::size_t total) {
+    const std::size_t safeTotal = std::max<std::size_t>(1, total);
+    const std::size_t safeDone = std::min(done, safeTotal);
+    const int y = LINES - 1;
+    const int barX = 2;
+    const int barWidth = std::max(10, COLS - 24);
+    const int filled = static_cast<int>((static_cast<double>(safeDone) / static_cast<double>(safeTotal)) * static_cast<double>(barWidth));
+
+    mvhline(y, 0, ' ', COLS);
+    mvprintw(y, 1, "%3zu%%", static_cast<std::size_t>((safeDone * 100) / safeTotal));
+    mvprintw(y, barX + 5 + barWidth, "%zu/%zu", safeDone, safeTotal);
+    mvprintw(y, barX, "[");
+    for (int i = 0; i < barWidth; ++i) {
+        addch(i < filled ? '#' : '-');
+    }
+    addch(']');
+}
+
+void drawLiveCleanResults(
+    const std::vector<Cleaner::CleanResult>& results,
+    std::size_t totalEntriesRemoved,
+    bool dryRun,
+    std::size_t done,
+    std::size_t total
+) {
+    clear();
+    drawCentered(1, dryRun ? "Cleaning result (running dry-run)" : "Cleaning result (running)");
+    mvprintw(3, 2, "%s%zu", dryRun ? "Dry-run entries removed: " : "Total entries removed: ", totalEntriesRemoved);
+
+    const int panelLeft = 2;
+    const int panelWidth = std::max(20, COLS - 4);
+    const int nameW = 14;
+    const int riskW = 6;
+    const int statusW = 10;
+    const int entriesW = 8;
+    const int fixedColumns = nameW + riskW + statusW + entriesW + 4;
+    const int pathW = std::max(8, panelWidth - fixedColumns);
+
+    if (has_colors()) {
+        attron(COLOR_PAIR(COLOR_HEADER));
+    }
+    mvprintw(5, panelLeft, "%-*s %-*s %-*s %*s %-*s", nameW, "NAME", riskW, "RISK", statusW, "STATUS", entriesW, "ENT", pathW, "PATH");
+    mvhline(6, panelLeft, '-', std::max(1, panelWidth));
+    if (has_colors()) {
+        attroff(COLOR_PAIR(COLOR_HEADER));
+    }
+
+    const int maxRows = std::max(1, LINES - 10);
+    const std::size_t start = results.size() > static_cast<std::size_t>(maxRows) ? results.size() - static_cast<std::size_t>(maxRows) : 0;
+    int row = 7;
+    for (std::size_t i = start; i < results.size() && row < LINES - 2; ++i) {
+        const auto& r = results[i];
+        const std::string entries = r.entries > 0 ? std::to_string(r.entries) : "-";
+        mvprintw(
+            row,
+            panelLeft,
+            "%-*s %-*s %-*s %*s %-*s",
+            nameW,
+            fitText(r.name, nameW).c_str(),
+            riskW,
+            fitText(r.risk, riskW).c_str(),
+            statusW,
+            fitText(r.status, statusW).c_str(),
+            entriesW,
+            entries.c_str(),
+            pathW,
+            fitText(r.path, pathW).c_str()
+        );
+        ++row;
+    }
+
+    mvprintw(LINES - 2, 2, "Processing... results update in real time");
+    drawFooterProgress(done, total);
+    refresh();
+}
+
+std::string formatBytes(std::uintmax_t bytes) {
+    static const char* units[] = {"B", "KB", "MB", "GB", "TB"};
+    double value = static_cast<double>(bytes);
+    int unitIndex = 0;
+    while (value >= 1024.0 && unitIndex < 4) {
+        value /= 1024.0;
+        ++unitIndex;
+    }
+
+    char buffer[64] = {0};
+    std::snprintf(buffer, sizeof(buffer), "%.2f %s", value, units[unitIndex]);
+    return std::string(buffer);
+}
+
+std::string timestampNow() {
+    const std::time_t now = std::time(nullptr);
+    char buffer[32] = {0};
+    const std::tm* local = std::localtime(&now);
+    if (!local) {
+        return "unknown-time";
+    }
+    std::strftime(buffer, sizeof(buffer), "%Y-%m-%d %H:%M:%S", local);
+    return std::string(buffer);
+}
+
+std::string jsonEscape(const std::string& input) {
+    std::string out;
+    out.reserve(input.size() + 8);
+    for (const char ch : input) {
+        switch (ch) {
+            case '"': out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\n': out += "\\n"; break;
+            case '\r': out += "\\r"; break;
+            case '\t': out += "\\t"; break;
+            default: out += ch; break;
+        }
+    }
+    return out;
+}
+
+std::string fitText(const std::string& text, int width) {
+    if (width <= 0) {
+        return "";
+    }
+    if (static_cast<int>(text.size()) <= width) {
+        return text;
+    }
+    if (width <= 3) {
+        return text.substr(0, static_cast<std::size_t>(width));
+    }
+    return text.substr(0, static_cast<std::size_t>(width - 3)) + "...";
+}
+
+struct TableLayout {
+    int panelLeft{2};
+    int panelWidth{20};
+    int selW{3};
+    int nameW{12};
+    int riskW{6};
+    int entriesW{10};
+    int sizeW{10};
+    int pathW{8};
+    bool compact{false};
+};
+
+TableLayout buildLayout() {
+    TableLayout layout;
+    layout.panelWidth = std::max(20, COLS - 4);
+    layout.compact = COLS < 100;
+    if (layout.compact) {
+        layout.entriesW = 8;
+        layout.sizeW = 0;
+    }
+
+    const int fixedColumns = layout.selW + layout.nameW + layout.riskW + layout.entriesW + layout.sizeW + 5;
+    layout.pathW = std::max(8, layout.panelWidth - fixedColumns);
+    return layout;
+}
+
+void drawTableHeader(const TableLayout& layout, int row) {
+    if (has_colors()) {
+        attron(COLOR_PAIR(COLOR_HEADER));
+    }
+    if (layout.compact) {
+        mvprintw(
+            row,
+            layout.panelLeft,
+            "%-*s %-*s %-*s %*s %-*s",
+            layout.selW,
+            "SEL",
+            layout.nameW,
+            "NAME",
+            layout.riskW,
+            "RISK",
+            layout.entriesW,
+            "ENT",
+            layout.pathW,
+            "PATH"
+        );
+    } else {
+        mvprintw(
+            row,
+            layout.panelLeft,
+            "%-*s %-*s %-*s %*s %*s %-*s",
+            layout.selW,
+            "SEL",
+            layout.nameW,
+            "NAME",
+            layout.riskW,
+            "RISK",
+            layout.entriesW,
+            "ENTRIES",
+            layout.sizeW,
+            "SIZE",
+            layout.pathW,
+            "PATH"
+        );
+    }
+    mvhline(row + 1, layout.panelLeft, '-', std::max(1, layout.panelWidth));
+    if (has_colors()) {
+        attroff(COLOR_PAIR(COLOR_HEADER));
+    }
+}
+
+void drawTableRow(
+    int row,
+    const TableLayout& layout,
+    const std::string& mark,
+    const std::string& name,
+    const std::string& risk,
+    const std::string& entries,
+    const std::string& size,
+    const std::string& path
+) {
+    if (layout.compact) {
+        mvprintw(
+            row,
+            layout.panelLeft,
+            "%-*s %-*s %-*s %*s %-*s",
+            layout.selW,
+            mark.c_str(),
+            layout.nameW,
+            fitText(name, layout.nameW).c_str(),
+            layout.riskW,
+            fitText(risk, layout.riskW).c_str(),
+            layout.entriesW,
+            fitText(entries, layout.entriesW).c_str(),
+            layout.pathW,
+            fitText(path, layout.pathW).c_str()
+        );
+    } else {
+        mvprintw(
+            row,
+            layout.panelLeft,
+            "%-*s %-*s %-*s %*s %*s %-*s",
+            layout.selW,
+            mark.c_str(),
+            layout.nameW,
+            fitText(name, layout.nameW).c_str(),
+            layout.riskW,
+            fitText(risk, layout.riskW).c_str(),
+            layout.entriesW,
+            fitText(entries, layout.entriesW).c_str(),
+            layout.sizeW,
+            fitText(size, layout.sizeW).c_str(),
+            layout.pathW,
+            fitText(path, layout.pathW).c_str()
+        );
+    }
+}
+
+void buildPreviewSummary(
+    const std::vector<CleaningItem>& items,
+    const std::vector<Cleaner::ItemPreview>& previews,
+    std::size_t& totalEntries,
+    std::uintmax_t& totalBytes,
+    std::vector<std::string>* lines
+) {
+    totalEntries = 0;
+    totalBytes = 0;
+    if (lines) {
+        lines->clear();
+    }
+
+    const std::size_t limit = std::min(items.size(), previews.size());
+    for (std::size_t i = 0; i < limit; ++i) {
+        const auto& item = items[i];
+        const auto& preview = previews[i];
+        if (!item.selected) {
+            continue;
+        }
+
+        const std::string risk = !preview.accessible ? "deny" : item.risk;
+        if (!preview.exists) {
+            if (lines) {
+                lines->push_back(item.name + " [" + risk + "]: missing");
+            }
+            continue;
+        }
+        if (!preview.accessible) {
+            if (lines) {
+                lines->push_back(item.name + " [" + risk + "]: access denied");
+            }
+            continue;
+        }
+
+        totalEntries += preview.entries;
+        totalBytes += preview.bytes;
+
+        if (lines) {
+            lines->push_back(
+                item.name +
+                " [" + risk + "]: " +
+                std::to_string(preview.entries) +
+                " entries, " +
+                std::to_string(preview.bytes) +
+                " bytes"
+            );
+        }
+    }
+}
+}
+
+Tui::Tui(bool dryRun) : dryRun_(dryRun) {}
+
+void Tui::requestPreviewRefresh() {
+    previewRefreshRequested_ = true;
+}
+
+bool Tui::cacheMatchesCurrentItems() const {
+    if (cachedPreviewItems_.size() != cleaner_.items().size() || cachedPreviews_.size() != cleaner_.items().size()) {
+        return false;
+    }
+
+    for (std::size_t i = 0; i < cleaner_.items().size(); ++i) {
+        if (cachedPreviewItems_[i].path != cleaner_.items()[i].path) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void Tui::startPreviewJobIfNeeded() {
+    if (previewJobRunning_ || !previewRefreshRequested_) {
+        return;
+    }
+
+    const std::vector<CleaningItem> snapshot = cleaner_.items();
+    previewRefreshRequested_ = false;
+    previewJobRunning_ = true;
+
+    previewFuture_ = std::async(std::launch::async, [this, snapshot]() {
+        PreviewJobResult result;
+        result.items = snapshot;
+        result.previews = cleaner_.previewItemsFor(snapshot);
+        return result;
+    });
+}
+
+void Tui::collectPreviewJobIfReady() {
+    if (!previewJobRunning_ || !previewFuture_.valid()) {
+        return;
+    }
+
+    if (previewFuture_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    auto result = previewFuture_.get();
+    cachedPreviewItems_ = std::move(result.items);
+    cachedPreviews_ = std::move(result.previews);
+    previewJobRunning_ = false;
+}
+
+int Tui::run() {
+    initscr();
+    cbreak();
+    noecho();
+    keypad(stdscr, TRUE);
+    curs_set(0);
+    initColors();
+
+    cleaner_.scan();
+
+    bool running = true;
+    int current = 0;
+    int listOffset = 0;
+    bool accessDialogShown = false;
+    std::string riskFilter = "all";
+
+    while (running) {
+        collectPreviewJobIfReady();
+        startPreviewJobIfNeeded();
+
+        clear();
+        drawCentered(1, "Mac Cleaner TUI");
+        if (dryRun_) {
+            drawCentered(2, "DRY-RUN mode (no deletion)   Arrows: move   Space: toggle   Enter: clean   q: quit");
+        } else {
+            drawCentered(2, "Arrows: move   Space: toggle   Enter: clean   q: quit");
+        }
+
+        std::vector<std::string> previewLines;
+        std::uintmax_t previewBytes = 0;
+        std::size_t previewEntries = 0;
+
+        std::vector<Cleaner::ItemPreview> itemPreviews(cleaner_.items().size());
+        const bool previewReady = cacheMatchesCurrentItems();
+        if (previewReady) {
+            itemPreviews = cachedPreviews_;
+            buildPreviewSummary(cleaner_.items(), itemPreviews, previewEntries, previewBytes, &previewLines);
+            mvprintw(3, 2, "Selected preview: %zu entries, %s", previewEntries, formatBytes(previewBytes).c_str());
+        } else {
+            mvprintw(3, 2, "Selected preview: scanning... (async)");
+        }
+
+        std::size_t safeSelected = 0;
+        std::size_t skippedSelected = 0;
+        std::size_t deniedSelected = 0;
+        std::vector<std::string> deniedPaths;
+        for (std::size_t i = 0; i < cleaner_.items().size(); ++i) {
+            const auto& item = cleaner_.items()[i];
+            if (!item.selected) {
+                continue;
+            }
+            const auto& preview = itemPreviews[i];
+            if (!preview.accessible) {
+                ++deniedSelected;
+                deniedPaths.push_back(item.path);
+            } else if (item.risk == "safe") {
+                ++safeSelected;
+            } else {
+                ++skippedSelected;
+            }
+        }
+        mvprintw(4, 2, "Risk summary: safe=%zu  skipped=%zu  denied=%zu", safeSelected, skippedSelected, deniedSelected);
+
+        const TableLayout layout = buildLayout();
+        const int panelTop = 5;
+        const int panelBottom = std::max(panelTop + 6, LINES - 3);
+        const int panelLeft = 1;
+        const int panelRight = std::max(panelLeft + 10, COLS - 2);
+
+        mvaddch(panelTop, panelLeft, ACS_ULCORNER);
+        mvhline(panelTop, panelLeft + 1, ACS_HLINE, std::max(1, panelRight - panelLeft - 1));
+        mvaddch(panelTop, panelRight, ACS_URCORNER);
+        for (int row = panelTop + 1; row < panelBottom; ++row) {
+            mvaddch(row, panelLeft, ACS_VLINE);
+            mvaddch(row, panelRight, ACS_VLINE);
+        }
+        mvaddch(panelBottom, panelLeft, ACS_LLCORNER);
+        mvhline(panelBottom, panelLeft + 1, ACS_HLINE, std::max(1, panelRight - panelLeft - 1));
+        mvaddch(panelBottom, panelRight, ACS_LRCORNER);
+        mvprintw(panelTop, panelLeft + 3, " Cleaner Targets ");
+
+        drawTableHeader(layout, panelTop + 1);
+
+        std::vector<int> filteredIndexes;
+        filteredIndexes.reserve(cleaner_.items().size());
+        for (std::size_t i = 0; i < cleaner_.items().size(); ++i) {
+            const auto& item = cleaner_.items()[i];
+            if (riskFilter == "all" || item.risk == riskFilter) {
+                filteredIndexes.push_back(static_cast<int>(i));
+            }
+        }
+
+        const int visibleRows = std::max(1, panelBottom - (panelTop + 3));
+        const int itemCount = static_cast<int>(filteredIndexes.size());
+
+        if (itemCount <= 0) {
+            current = 0;
+            listOffset = 0;
+        } else {
+            current = std::clamp(current, 0, itemCount - 1);
+            listOffset = std::clamp(listOffset, 0, std::max(0, itemCount - visibleRows));
+            if (current < listOffset) {
+                listOffset = current;
+            }
+            if (current >= listOffset + visibleRows) {
+                listOffset = current - visibleRows + 1;
+            }
+        }
+
+        int row = panelTop + 3;
+        for (int i = listOffset; i < itemCount; ++i) {
+            if (row >= panelBottom) {
+                break;
+            }
+            const int sourceIndex = filteredIndexes[static_cast<std::size_t>(i)];
+            const auto& item = cleaner_.items()[static_cast<std::size_t>(sourceIndex)];
+            const auto& preview = itemPreviews[static_cast<std::size_t>(sourceIndex)];
+            const std::string mark = item.selectable ? (item.selected ? "[x]" : "[ ]") : "[-]";
+            const std::string risk = !preview.accessible ? "deny" : item.risk;
+            const std::string entries = (!preview.exists || !preview.accessible) ? "-" : std::to_string(preview.entries);
+            const std::string size = (!preview.exists || !preview.accessible) ? "-" : formatBytes(preview.bytes);
+
+            if (i == current) {
+                attron(A_REVERSE | A_BOLD);
+            } else if (!item.selectable) {
+                if (has_colors() && item.hidden) {
+                    attron(COLOR_PAIR(COLOR_HIDDEN));
+                }
+                attron(A_DIM);
+            } else if (has_colors()) {
+                if (item.hidden) {
+                    attron(COLOR_PAIR(COLOR_HIDDEN));
+                } else if (risk == "safe") {
+                    attron(COLOR_PAIR(COLOR_SAFE));
+                } else {
+                    attron(COLOR_PAIR(COLOR_SKIP));
+                }
+            } else if (!item.selected) {
+                attron(A_DIM);
+            }
+
+            drawTableRow(row++, layout, mark, item.name, risk, entries, size, item.path);
+
+            if (i == current) {
+                attroff(A_REVERSE | A_BOLD);
+            } else if (!item.selectable) {
+                attroff(A_DIM);
+                if (has_colors() && item.hidden) {
+                    attroff(COLOR_PAIR(COLOR_HIDDEN));
+                }
+            } else if (has_colors()) {
+                if (item.hidden) {
+                    attroff(COLOR_PAIR(COLOR_HIDDEN));
+                } else if (risk == "safe") {
+                    attroff(COLOR_PAIR(COLOR_SAFE));
+                } else {
+                    attroff(COLOR_PAIR(COLOR_SKIP));
+                }
+            } else if (!item.selected) {
+                attroff(A_DIM);
+            }
+        }
+
+        if (itemCount > 0) {
+            const int activeSourceIndex = filteredIndexes[static_cast<std::size_t>(current)];
+            const auto& activeItem = cleaner_.items()[static_cast<std::size_t>(activeSourceIndex)];
+            const auto& activePreview = itemPreviews[static_cast<std::size_t>(activeSourceIndex)];
+            const std::string activeRisk = !activePreview.accessible ? "deny" : activeItem.risk;
+            const std::string activeEntries = (!activePreview.exists || !activePreview.accessible) ? "-" : std::to_string(activePreview.entries);
+            const std::string activeSize = (!activePreview.exists || !activePreview.accessible) ? "-" : formatBytes(activePreview.bytes);
+            drawStatusBar(
+                "Item=" + activeItem.name +
+                "  Filter=" + riskFilter +
+                "  Risk=" + activeRisk +
+                "  Selectable=" + std::string(activeItem.selectable ? "yes" : "no") +
+                "  Entries=" + activeEntries +
+                "  Size=" + activeSize +
+                "  Path=" + activeItem.path
+            );
+        } else {
+            drawStatusBar("No cleanup categories available for filter=" + riskFilter + " (use /all, /safe, /review, /never)");
+        }
+
+        drawBottomBar();
+
+        refresh();
+
+        if (deniedSelected > 0 && !accessDialogShown) {
+            showAccessDeniedDialog(deniedPaths);
+            accessDialogShown = true;
+        }
+        if (deniedSelected == 0) {
+            accessDialogShown = false;
+        }
+
+        const auto showHelp = []() {
+            const std::vector<std::string> lines = {
+                "NAME",
+                "    mcleaner - interactive cache/log cleaner for macOS user paths",
+                "",
+                "SYNOPSIS",
+                "    mcleaner",
+                "    mcleaner --dry-run",
+                "",
+                "DESCRIPTION",
+                "    Single-panel commander-style interface for selecting cleanup targets.",
+                "    The cleaner only acts on safe paths under the current HOME directory.",
+                "",
+                "COMMANDS",
+                "    1, Space       Toggle current row",
+                "    2              Select all rows",
+                "    3              Deselect all rows",
+                "    4              Open preview table",
+                "    5, Enter       Clean selected rows (with confirmation)",
+                "    6              Rescan default targets",
+                "    7              Scan hidden home directories",
+                "    8              Confirm-mark current review row",
+                "    /risk          Filter rows by risk (all/safe/review/never)",
+                "    9              Open this help screen",
+                "    0, q, F10      Quit application",
+                "",
+                "NAVIGATION",
+                "    Up, Down       Move current row",
+                "    PgUp, PgDn     Scroll one page",
+                "    Home, End      Jump to first/last row",
+                "    Ctrl+U, Ctrl+D Scroll half page up/down",
+                "",
+                "FILES",
+                "    ~/Library/Logs/mcleaner.log",
+                "    ~/Library/Logs/mcleaner-last-report.json",
+                "",
+                "NOTES",
+                "    Unsafe paths are skipped and reported in logs/results.",
+                "    Preview and cleanup outputs are paginated for narrow terminals."
+            };
+            showPagedLines("MAC CLEANER TUI", "General Commands Manual", lines);
+        };
+
+        const auto runPreview = [this, &previewLines]() {
+            if (!cacheMatchesCurrentItems()) {
+                const std::vector<std::string> lines = {
+                    "Preview is still loading in background.",
+                    "Please wait a moment and try again.",
+                };
+                showPagedLines("Preview loading", "Asynchronous scan in progress", lines);
+                return;
+            }
+
+            std::size_t entries = 0;
+            std::uintmax_t bytes = 0;
+            buildPreviewSummary(cleaner_.items(), cachedPreviews_, entries, bytes, &previewLines);
+            showPreviewTable(cleaner_.items(), cachedPreviews_, entries, bytes);
+            appendPreviewLog(entries, bytes, previewLines);
+        };
+
+        const auto runClean = [this]() {
+            if (!confirmClean()) {
+                return;
+            }
+            std::vector<CleaningItem> selectedItems;
+            for (const auto& item : cleaner_.items()) {
+                if (item.selected) {
+                    selectedItems.push_back(item);
+                }
+            }
+
+            if (selectedItems.empty()) {
+                const std::vector<std::string> lines = {"No selected rows to process."};
+                showPagedLines("Cleaning result", "Nothing to do", lines);
+                return;
+            }
+
+            using TaskResult = std::pair<Cleaner::CleanResult, std::size_t>;
+            std::vector<std::future<TaskResult>> futures;
+            futures.reserve(selectedItems.size());
+            for (const auto& item : selectedItems) {
+                futures.push_back(std::async(std::launch::async, [this, item]() {
+                    const Cleaner::CleanResult result = cleaner_.cleanItem(item, dryRun_);
+                    const std::size_t removed = (result.status == "removed") ? result.entries : 0;
+                    return TaskResult{result, removed};
+                }));
+            }
+
+            std::vector<bool> finished(futures.size(), false);
+            std::vector<Cleaner::CleanResult> cleanResults;
+            cleanResults.reserve(futures.size());
+            std::size_t completed = 0;
+            std::size_t removed = 0;
+
+            while (completed < futures.size()) {
+                for (std::size_t i = 0; i < futures.size(); ++i) {
+                    if (finished[i]) {
+                        continue;
+                    }
+                    if (futures[i].wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+                        TaskResult r = futures[i].get();
+                        finished[i] = true;
+                        ++completed;
+                        removed += r.second;
+                        cleanResults.push_back(std::move(r.first));
+                    }
+                }
+
+                drawLiveCleanResults(cleanResults, removed, dryRun_, completed, futures.size());
+                std::this_thread::sleep_for(std::chrono::milliseconds(35));
+            }
+
+            std::vector<std::string> messages;
+            messages.reserve(cleanResults.size());
+            for (const auto& row : cleanResults) {
+                messages.push_back(row.name + ": " + row.detail);
+            }
+
+            requestPreviewRefresh();
+            showCleanResultTable(cleanResults, removed, dryRun_);
+            appendCleanLog(removed, messages);
+            writeJsonReport(removed, messages);
+        };
+
+        const auto runHiddenScan = [this]() {
+            std::vector<std::string> messages;
+            const std::size_t added = cleaner_.scanHiddenCandidates(messages);
+            requestPreviewRefresh();
+            showPagedLines(
+                "HiddenScan result",
+                "Added candidates: " + std::to_string(added),
+                messages
+            );
+        };
+
+        const auto runRiskFilterPrompt = [&riskFilter, &current, &listOffset]() {
+            echo();
+            curs_set(1);
+
+            char input[32] = {0};
+            mvhline(LINES - 2, 0, ' ', COLS);
+            mvprintw(LINES - 2, 1, "Filter risk (/all, /safe, /review, /never): /");
+            move(LINES - 2, 47);
+            getnstr(input, 16);
+
+            noecho();
+            curs_set(0);
+
+            std::string value(input);
+            if (value == "all" || value == "safe" || value == "review" || value == "never") {
+                riskFilter = value;
+                current = 0;
+                listOffset = 0;
+            }
+        };
+
+        const int ch = getch();
+        switch (ch) {
+            case 'q':
+            case '0':
+            case KEY_F(10):
+                running = false;
+                break;
+            case 'r':
+            case '6':
+            case KEY_F(6):
+                cleaner_.scan();
+                requestPreviewRefresh();
+                break;
+            case '7':
+            case KEY_F(7):
+                runHiddenScan();
+                break;
+            case '8':
+            case KEY_F(8):
+                if (itemCount > 0) {
+                    const int sourceIndex = filteredIndexes[static_cast<std::size_t>(current)];
+                    auto& item = cleaner_.items()[static_cast<std::size_t>(sourceIndex)];
+                    if (item.hidden && item.risk == "review" && confirmReviewSelection(item)) {
+                        item.selectable = true;
+                        item.selected = true;
+                        requestPreviewRefresh();
+                    }
+                }
+                break;
+            case '/':
+                runRiskFilterPrompt();
+                break;
+            case 'a':
+            case '2':
+            case KEY_F(2):
+                selectAll(true);
+                break;
+            case 'n':
+            case '3':
+            case KEY_F(3):
+                selectAll(false);
+                break;
+            case 'p':
+            case '4':
+            case KEY_F(4):
+                runPreview();
+                break;
+            case 'c':
+            case '5':
+            case KEY_F(5):
+            case 10:
+            case 13:
+                runClean();
+                break;
+            case 'h':
+            case '9':
+            case KEY_F(9):
+                showHelp();
+                break;
+            case KEY_UP:
+                if (itemCount > 0) {
+                    current = std::max(0, current - 1);
+                }
+                break;
+            case KEY_DOWN:
+                if (itemCount > 0) {
+                    current = std::min(current + 1, itemCount - 1);
+                }
+                break;
+            case KEY_HOME:
+                if (itemCount > 0) {
+                    current = 0;
+                }
+                break;
+            case KEY_END:
+                if (itemCount > 0) {
+                    current = itemCount - 1;
+                }
+                break;
+            case KEY_PPAGE:
+                if (itemCount > 0) {
+                    current = std::max(0, current - visibleRows);
+                }
+                break;
+            case KEY_NPAGE:
+                if (itemCount > 0) {
+                    current = std::min(itemCount - 1, current + visibleRows);
+                }
+                break;
+            case 21:  // Ctrl+U
+                if (itemCount > 0) {
+                    const int half = std::max(1, visibleRows / 2);
+                    current = std::max(0, current - half);
+                }
+                break;
+            case 4:  // Ctrl+D
+                if (itemCount > 0) {
+                    const int half = std::max(1, visibleRows / 2);
+                    current = std::min(itemCount - 1, current + half);
+                }
+                break;
+            case ' ':
+            case '1':
+            case KEY_F(1):
+                if (itemCount > 0) {
+                    toggleItem(filteredIndexes[static_cast<std::size_t>(current)]);
+                }
+                break;
+            default: break;
+        }
+    }
+
+    if (previewFuture_.valid()) {
+        previewFuture_.wait();
+    }
+
+    endwin();
+    return 0;
+}
+
+bool Tui::confirmClean() {
+    clear();
+    drawCentered(1, "Confirm clean");
+    mvprintw(3, 2, "This action removes files from selected locations.");
+    mvprintw(4, 2, "Press Enter to continue or ESC to cancel.");
+    refresh();
+    const int ch = getch();
+    return ch == 10 || ch == 13 || ch == KEY_ENTER;
+}
+
+bool Tui::confirmReviewSelection(const CleaningItem& item) {
+    const int width = std::min(std::max(42, COLS - 10), 76);
+    const int height = 11;
+    const int startY = std::max(1, (LINES - height) / 2);
+    const int startX = std::max(2, (COLS - width) / 2);
+
+    WINDOW* win = newwin(height, width, startY, startX);
+    if (!win) {
+        return false;
+    }
+
+    keypad(win, TRUE);
+    if (has_colors()) {
+        wbkgd(win, COLOR_PAIR(COLOR_MODAL_WARNING));
+    }
+    werase(win);
+    box(win, 0, 0);
+    wattron(win, A_BOLD);
+    mvwprintw(win, 1, 3, "Risk Confirmation");
+    wattroff(win, A_BOLD);
+
+    mvwprintw(win, 3, 2, "This row has risk=review and is not selected by default.");
+    mvwprintw(win, 4, 2, "If you confirm, it will be marked for deletion.");
+    mvwprintw(win, 6, 2, "Name: %s", fitText(item.name, width - 10).c_str());
+    mvwprintw(win, 7, 2, "Path: %s", fitText(item.path, width - 10).c_str());
+    mvwprintw(win, 9, 2, "Press Enter to confirm or ESC to cancel.");
+
+    wrefresh(win);
+    const int ch = wgetch(win);
+    delwin(win);
+    return ch == 10 || ch == 13 || ch == KEY_ENTER;
+}
+
+void Tui::showAccessDeniedDialog(const std::vector<std::string>& deniedPaths) {
+    const int width = std::min(std::max(36, COLS - 8), 66);
+    const int height = std::min(LINES - 4, 12 + static_cast<int>(std::min<std::size_t>(3, deniedPaths.size())));
+    const int startY = std::max(1, (LINES - height) / 2);
+    const int startX = std::max(2, (COLS - width) / 2);
+
+    WINDOW* win = newwin(height, width, startY, startX);
+    if (!win) {
+        return;
+    }
+
+    keypad(win, TRUE);
+    if (has_colors()) {
+        wbkgd(win, COLOR_PAIR(COLOR_MODAL_ERROR));
+    }
+    werase(win);
+    box(win, 0, 0);
+
+    wattron(win, A_BOLD);
+    mvwprintw(win, 1, 3, "Access Error");
+    wattroff(win, A_BOLD);
+
+    mvwprintw(win, 3, 2, "Cannot access one or more directories.");
+    mvwprintw(win, 4, 2, "Grant Full Disk Access to your terminal emulator.");
+    mvwprintw(win, 5, 2, "Settings -> Privacy & Security -> Full Disk Access");
+
+    int row = 7;
+    for (std::size_t i = 0; i < deniedPaths.size() && i < 3; ++i) {
+        const std::string path = fitText(deniedPaths[i], width - 6);
+        mvwprintw(win, row++, 2, "- %s", path.c_str());
+    }
+
+    mvwprintw(win, height - 2, 2, "Press ESC to continue...");
+    wrefresh(win);
+
+    while (true) {
+        const int ch = wgetch(win);
+        if (ch == 27) {
+            break;
+        }
+    }
+
+    delwin(win);
+}
+
+void Tui::drawProgress(std::size_t done, std::size_t total, const std::string& label) {
+    clear();
+    drawCentered(1, "Cleaning in progress");
+
+    const int barWidth = std::max(10, COLS - 20);
+    const std::size_t clampedTotal = std::max<std::size_t>(1, total);
+    const std::size_t clampedDone = std::min(done, clampedTotal);
+    const int filled = static_cast<int>((static_cast<double>(clampedDone) / static_cast<double>(clampedTotal)) * static_cast<double>(barWidth));
+
+    mvprintw(3, 2, "Current: %s", label.c_str());
+    mvprintw(4, 2, "Progress: %zu/%zu", clampedDone, clampedTotal);
+    mvprintw(6, 2, "[");
+    for (int i = 0; i < barWidth; ++i) {
+        addch(i < filled ? '#' : '-');
+    }
+    addch(']');
+    refresh();
+}
+
+void Tui::showPagedLines(
+    const std::string& title,
+    const std::string& summary,
+    const std::vector<std::string>& lines,
+    const std::string& footerLeft,
+    const std::string& footerRight
+) {
+    const std::size_t pageSize = static_cast<std::size_t>(std::max(1, LINES - 8));
+    const std::size_t pageCount = std::max<std::size_t>(1, (lines.size() + pageSize - 1) / pageSize);
+    std::size_t page = 0;
+
+    while (true) {
+        clear();
+        drawCentered(1, title);
+        mvprintw(3, 2, "%s", summary.c_str());
+
+        if (lines.empty()) {
+            mvprintw(5, 2, "(no items)");
+        } else {
+            const std::size_t begin = page * pageSize;
+            const std::size_t end = std::min(begin + pageSize, lines.size());
+            int row = 5;
+            for (std::size_t i = begin; i < end && row < LINES - 2; ++i) {
+                mvprintw(row++, 2, "%s", lines[i].c_str());
+            }
+        }
+
+        mvprintw(
+            LINES - 2,
+            2,
+            "Page %zu/%zu  n:next  p:prev  q/Enter:back",
+            page + 1,
+            pageCount
+        );
+
+        if (!footerLeft.empty() || !footerRight.empty()) {
+            mvhline(LINES - 1, 0, ' ', COLS);
+            mvprintw(LINES - 1, 1, "%s", fitText(footerLeft, std::max(1, COLS - 2)).c_str());
+            const int rightLen = static_cast<int>(footerRight.size());
+            const int rightX = std::max(1, COLS - rightLen - 1);
+            mvprintw(LINES - 1, rightX, "%s", footerRight.c_str());
+        }
+        refresh();
+
+        const int ch = getch();
+        if (ch == 'q' || ch == 10 || ch == 13 || ch == 27) {
+            break;
+        }
+        if ((ch == 'n' || ch == KEY_RIGHT || ch == KEY_DOWN) && page + 1 < pageCount) {
+            ++page;
+        }
+        if ((ch == 'p' || ch == KEY_LEFT || ch == KEY_UP) && page > 0) {
+            --page;
+        }
+    }
+}
+
+void Tui::showPreviewTable(
+    const std::vector<CleaningItem>& items,
+    const std::vector<Cleaner::ItemPreview>& previews,
+    std::size_t totalEntries,
+    std::uintmax_t totalBytes
+) {
+    std::vector<std::size_t> visibleIndexes;
+    for (std::size_t i = 0; i < items.size() && i < previews.size(); ++i) {
+        visibleIndexes.push_back(i);
+    }
+
+    const std::size_t pageSize = static_cast<std::size_t>(std::max(1, LINES - 11));
+    const std::size_t pageCount = std::max<std::size_t>(1, (visibleIndexes.size() + pageSize - 1) / pageSize);
+    std::size_t page = 0;
+
+    while (true) {
+        clear();
+        drawCentered(1, "Preview overview");
+        mvprintw(3, 2, "Total: %zu entries, %s", totalEntries, formatBytes(totalBytes).c_str());
+
+        const TableLayout layout = buildLayout();
+        drawTableHeader(layout, 5);
+
+        const std::size_t begin = page * pageSize;
+        const std::size_t end = std::min(begin + pageSize, visibleIndexes.size());
+
+        int row = 7;
+        for (std::size_t pos = begin; pos < end && row < LINES - 2; ++pos) {
+            const std::size_t idx = visibleIndexes[pos];
+            const auto& item = items[idx];
+            const auto& preview = previews[idx];
+
+            const std::string mark = item.selectable ? (item.selected ? "[x]" : "[ ]") : "[-]";
+            const std::string risk = !preview.accessible ? "deny" : item.risk;
+            const std::string entries = (!preview.exists || !preview.accessible) ? "-" : std::to_string(preview.entries);
+            const std::string size = (!preview.exists || !preview.accessible) ? "-" : formatBytes(preview.bytes);
+            drawTableRow(row++, layout, mark, item.name, risk, entries, size, item.path);
+        }
+
+        if (visibleIndexes.empty()) {
+            mvprintw(8, 2, "No rows.");
+        }
+
+        mvprintw(
+            LINES - 2,
+            2,
+            "Page %zu/%zu  n:next  p:prev  q/Enter:back",
+            page + 1,
+            pageCount
+        );
+        refresh();
+
+        const int ch = getch();
+        if (ch == 'q' || ch == 10 || ch == 13 || ch == 27) {
+            break;
+        }
+        if ((ch == 'n' || ch == KEY_RIGHT || ch == KEY_DOWN) && page + 1 < pageCount) {
+            ++page;
+        }
+        if ((ch == 'p' || ch == KEY_LEFT || ch == KEY_UP) && page > 0) {
+            --page;
+        }
+    }
+}
+
+void Tui::showCleanResultTable(
+    const std::vector<Cleaner::CleanResult>& results,
+    std::size_t totalEntriesRemoved,
+    bool dryRun
+) {
+    const std::size_t pageSize = static_cast<std::size_t>(std::max(1, LINES - 11));
+    const std::size_t pageCount = std::max<std::size_t>(1, (results.size() + pageSize - 1) / pageSize);
+    std::size_t page = 0;
+
+    while (true) {
+        clear();
+        drawCentered(1, dryRun ? "Cleaning result (dry-run)" : "Cleaning result");
+        mvprintw(3, 2, "%s%zu", dryRun ? "Dry-run entries removed: " : "Total entries removed: ", totalEntriesRemoved);
+
+        const int panelLeft = 2;
+        const int panelWidth = std::max(20, COLS - 4);
+        const int nameW = 14;
+        const int riskW = 6;
+        const int statusW = 10;
+        const int entriesW = 8;
+        const int fixedColumns = nameW + riskW + statusW + entriesW + 4;
+        const int pathW = std::max(8, panelWidth - fixedColumns);
+
+        if (has_colors()) {
+            attron(COLOR_PAIR(COLOR_HEADER));
+        }
+        mvprintw(5, panelLeft, "%-*s %-*s %-*s %*s %-*s", nameW, "NAME", riskW, "RISK", statusW, "STATUS", entriesW, "ENT", pathW, "PATH");
+        mvhline(6, panelLeft, '-', std::max(1, panelWidth));
+        if (has_colors()) {
+            attroff(COLOR_PAIR(COLOR_HEADER));
+        }
+
+        const std::size_t begin = page * pageSize;
+        const std::size_t end = std::min(begin + pageSize, results.size());
+        int row = 7;
+        for (std::size_t i = begin; i < end && row < LINES - 2; ++i) {
+            const auto& r = results[i];
+            const std::string entries = r.entries > 0 ? std::to_string(r.entries) : "-";
+
+            if (has_colors()) {
+                if (r.risk == "safe") {
+                    attron(COLOR_PAIR(COLOR_SAFE));
+                } else if (r.risk == "review" || r.risk == "never") {
+                    attron(COLOR_PAIR(COLOR_HIDDEN));
+                }
+            }
+
+            mvprintw(
+                row++,
+                panelLeft,
+                "%-*s %-*s %-*s %*s %-*s",
+                nameW,
+                fitText(r.name, nameW).c_str(),
+                riskW,
+                fitText(r.risk, riskW).c_str(),
+                statusW,
+                fitText(r.status, statusW).c_str(),
+                entriesW,
+                entries.c_str(),
+                pathW,
+                fitText(r.path, pathW).c_str()
+            );
+
+            if (has_colors()) {
+                int statusColor = 0;
+                if (r.status == "removed") {
+                    statusColor = COLOR_STATUS_OK;
+                } else if (r.status == "dry-run" || r.status == "skipped" || r.status == "missing") {
+                    statusColor = COLOR_STATUS_WARN;
+                } else if (r.status == "error") {
+                    statusColor = COLOR_STATUS_ERR;
+                }
+
+                if (statusColor != 0) {
+                    const int statusX = panelLeft + nameW + 1 + riskW + 1;
+                    attron(COLOR_PAIR(statusColor) | A_BOLD);
+                    mvprintw(row - 1, statusX, "%-*s", statusW, fitText(r.status, statusW).c_str());
+                    attroff(COLOR_PAIR(statusColor) | A_BOLD);
+                }
+            }
+
+            if (has_colors()) {
+                if (r.risk == "safe") {
+                    attroff(COLOR_PAIR(COLOR_SAFE));
+                } else if (r.risk == "review" || r.risk == "never") {
+                    attroff(COLOR_PAIR(COLOR_HIDDEN));
+                }
+            }
+        }
+
+        if (results.empty()) {
+            mvprintw(8, 2, "No selected rows were processed.");
+        }
+
+        mvprintw(LINES - 2, 2, "Page %zu/%zu  n:next  p:prev  q/Enter:back", page + 1, pageCount);
+        refresh();
+
+        const int ch = getch();
+        if (ch == 'q' || ch == 10 || ch == 13 || ch == 27) {
+            break;
+        }
+        if ((ch == 'n' || ch == KEY_RIGHT || ch == KEY_DOWN) && page + 1 < pageCount) {
+            ++page;
+        }
+        if ((ch == 'p' || ch == KEY_LEFT || ch == KEY_UP) && page > 0) {
+            --page;
+        }
+    }
+}
+
+void Tui::selectAll(bool selected) {
+    for (auto& item : cleaner_.items()) {
+        if (!item.selectable) {
+            item.selected = false;
+            continue;
+        }
+        item.selected = selected;
+    }
+}
+
+void Tui::appendLog(const std::vector<std::string>& lines) const {
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        return;
+    }
+
+    const std::filesystem::path logPath = std::filesystem::path(home) / "Library" / "Logs" / "mcleaner.log";
+    std::error_code ec;
+    std::filesystem::create_directories(logPath.parent_path(), ec);
+
+    std::ofstream out(logPath.string(), std::ios::app);
+    if (!out.is_open()) {
+        return;
+    }
+
+    for (const auto& line : lines) {
+        out << line << '\n';
+    }
+    out << '\n';
+}
+
+void Tui::appendCleanLog(std::size_t removed, const std::vector<std::string>& lines) const {
+    std::vector<std::string> output;
+    output.reserve(lines.size() + 3);
+    output.push_back("[" + timestampNow() + "] clean");
+    output.push_back("total entries removed: " + std::to_string(removed));
+    for (const auto& line : lines) {
+        output.push_back("- " + line);
+    }
+    appendLog(output);
+}
+
+void Tui::appendPreviewLog(std::size_t entries, std::uintmax_t bytes, const std::vector<std::string>& lines) const {
+    std::vector<std::string> output;
+    output.reserve(lines.size() + 3);
+    output.push_back("[" + timestampNow() + "] preview");
+    output.push_back("total preview: " + std::to_string(entries) + " entries, " + formatBytes(bytes));
+    for (const auto& line : lines) {
+        output.push_back("- " + line);
+    }
+    appendLog(output);
+}
+
+void Tui::writeJsonReport(std::size_t removed, const std::vector<std::string>& lines) const {
+    const char* home = std::getenv("HOME");
+    if (!home) {
+        return;
+    }
+
+    const std::filesystem::path reportPath = std::filesystem::path(home) / "Library" / "Logs" / "mcleaner-last-report.json";
+    std::error_code ec;
+    std::filesystem::create_directories(reportPath.parent_path(), ec);
+
+    std::ofstream out(reportPath.string(), std::ios::trunc);
+    if (!out.is_open()) {
+        return;
+    }
+
+    out << "{\n";
+    out << "  \"timestamp\": \"" << jsonEscape(timestampNow()) << "\",\n";
+    out << "  \"total_entries_removed\": " << removed << ",\n";
+    out << "  \"messages\": [\n";
+    for (std::size_t i = 0; i < lines.size(); ++i) {
+        out << "    \"" << jsonEscape(lines[i]) << "\"";
+        if (i + 1 < lines.size()) {
+            out << ",";
+        }
+        out << "\n";
+    }
+    out << "  ]\n";
+    out << "}\n";
+}
+
+void Tui::toggleItem(int index) {
+    if (index < 0 || index >= static_cast<int>(cleaner_.items().size())) return;
+    if (!cleaner_.items()[index].selectable) return;
+    cleaner_.items()[index].selected = !cleaner_.items()[index].selected;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,43 @@
+#include "Tui.h"
+
+#include <iostream>
+#include <string>
+
+#ifndef MCLEANER_VERSION
+#define MCLEANER_VERSION "dev"
+#endif
+
+namespace {
+void printHelp(const char* program) {
+    std::cout
+        << "Usage: " << program << " [--dry-run] [--help] [--version]\n"
+        << "\n"
+        << "Options:\n"
+        << "  --dry-run   Simulate cleaning without deleting files\n"
+        << "  --help      Show this help and exit\n"
+        << "  --version   Show version and exit\n";
+}
+}
+
+int main(int argc, char** argv) {
+    bool dryRun = false;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--dry-run") {
+            dryRun = true;
+        } else if (arg == "--help" || arg == "-h") {
+            printHelp(argv[0]);
+            return 0;
+        } else if (arg == "--version" || arg == "-v") {
+            std::cout << "mcleaner " << MCLEANER_VERSION << "\n";
+            return 0;
+        } else {
+            std::cerr << "Unknown option: " << arg << "\n\n";
+            printHelp(argv[0]);
+            return 1;
+        }
+    }
+
+    Tui tui(dryRun);
+    return tui.run();
+}


### PR DESCRIPTION
## Branch naming convention
- Feature: `feature/XX-description`
- Bugfix: `bugfix/XX-description`

## What changed
- 

## Why
- 

## How to test
1. `make`
2. Run: `./mcleaner`
3. Optional safe run: `./mcleaner --dry-run`

## Screenshots / terminal capture
If UI behavior changed, include before/after captures.

## Safety checklist
- [ ] I did not weaken `never` protections.
- [ ] `review` behavior remains explicit/confirmed.
- [ ] Access-denied handling remains clear.
- [ ] `--dry-run` performs no real deletion.
- [ ] I validated no unexpected destructive behavior.

## Notes for reviewers
- 
